### PR TITLE
feat: ability to specify the datacollector image

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,26 +30,27 @@ The `main.tf` file will configure a daemon Service within the specified ECS Clus
 
 ## Inputs
 
-| Name                    | Description                                                                         | Type          | Default                    | Required |
-| ----------------------- | ----------------------------------------------------------------------------------- | ------------- | -------------------------- | :------: |
-| ecs_cluster_arn         | The ARN of the ECS cluster in which to deploy the Lacework agent                    | `string`      | n/a                        |   yes    |
-| ecs_launch_type         | The desired launch type for the Lacework agent ECS Service                          | `string`      | `"EC2"`                    |    no    |
-| ecs_service_name        | The desired name for the Lacework agent ECS Service                                 | `string`      | `""`                       |    no    |
-| ecs_task_family_name    | The desired name for the Lacework agent ECS Task Definition                         | `string`      | `""`                       |    no    |
-| iam_role_arn            | The IAM role ARN to use when `use_existing_iam_role` is `true`                      | `string`      | `""`                       |    no    |
-| iam_role_name           | The IAM role name to use when `use_existing_iam_role` is `false`                    | `string`      | `""`                       |    no    |
-| iam_role_tags           | The tags to apply to a created IAM role                                             | `map(string)` | `{}`                       |    no    |
-| lacework_access_token   | The access token for the Lacework agent                                             | `string`      | n/a                        |   yes    |
-| lacework_server_url     | The server URL for the Lacework agent                                               | `string`      | `""`                       |    no    |
-| lacework_task_cpu       | The quantity of CPU units to assign to the task                                     | `string`      | `"512"`                    |    no    |
-| lacework_task_mem       | The quantity of Memory (MiB) to assign to the task                                  | `string`      | `"512"`                    |    no    |
-| resource_prefix         | A prefix that will be use at the beginning of every generated resource              | `string`      | `"lacework-ecs"`           |    no    |
-| ssm_parameter_arn       | An existing SSM parameter ARN. Can be used when `use_ssm_parameter_store` is `true` | `string`      | `""`                       |    no    |
-| ssm_parameter_encrypted | Set this to `true` if the SSM parameter is/should be encrypted                      | `bool`        | `false`                    |    no    |
-| ssm_parameter_kms_arn   | The ARN of the KMS key to use when `ssm_parameter_encrypted` is `true`              | `string`      | `""`                       |    no    |
-| ssm_parameter_name      | The name to use for the Lacework agent access token when using SSM                  | `string`      | `"/lacework/access_token"` |    no    |
-| use_existing_iam_role   | Set this to `true` to use an existing IAM role                                      | `bool`        | `false`                    |    no    |
-| use_ssm_parameter_store | Set this to `true` to use SSM to store the Lacework agent access token              | `bool`        | `false`                    |    no    |
+| Name                         | Description                                                                         | Type          | Default                           | Required |
+| ---------------------------- | ----------------------------------------------------------------------------------- | ------------- | --------------------------------- | :------: |
+| ecs_cluster_arn              | The ARN of the ECS cluster in which to deploy the Lacework agent                    | `string`      | n/a                               |   yes    |
+| ecs_launch_type              | The desired launch type for the Lacework agent ECS Service                          | `string`      | `"EC2"`                           |    no    |
+| ecs_service_name             | The desired name for the Lacework agent ECS Service                                 | `string`      | `""`                              |    no    |
+| ecs_task_family_name         | The desired name for the Lacework agent ECS Task Definition                         | `string`      | `""`                              |    no    |
+| iam_role_arn                 | The IAM role ARN to use when `use_existing_iam_role` is `true`                      | `string`      | `""`                              |    no    |
+| iam_role_name                | The IAM role name to use when `use_existing_iam_role` is `false`                    | `string`      | `""`                              |    no    |
+| iam_role_tags                | The tags to apply to a created IAM role                                             | `map(string)` | `{}`                              |    no    |
+| lacework_access_token        | The access token for the Lacework agent                                             | `string`      | n/a                               |   yes    |
+| lacework_datacollector_image | The image used to deploy the Lacework datacollector.                                | `string`      | `"lacework/datacollector:latest"` |    no    |
+| lacework_server_url          | The server URL for the Lacework agent                                               | `string`      | `""`                              |    no    |
+| lacework_task_cpu            | The quantity of CPU units to assign to the task                                     | `string`      | `"512"`                           |    no    |
+| lacework_task_mem            | The quantity of Memory (MiB) to assign to the task                                  | `string`      | `"512"`                           |    no    |
+| resource_prefix              | A prefix that will be use at the beginning of every generated resource              | `string`      | `"lacework-ecs"`                  |    no    |
+| ssm_parameter_arn            | An existing SSM parameter ARN. Can be used when `use_ssm_parameter_store` is `true` | `string`      | `""`                              |    no    |
+| ssm_parameter_encrypted      | Set this to `true` if the SSM parameter is/should be encrypted                      | `bool`        | `false`                           |    no    |
+| ssm_parameter_kms_arn        | The ARN of the KMS key to use when `ssm_parameter_encrypted` is `true`              | `string`      | `""`                              |    no    |
+| ssm_parameter_name           | The name to use for the Lacework agent access token when using SSM                  | `string`      | `"/lacework/access_token"`        |    no    |
+| use_existing_iam_role        | Set this to `true` to use an existing IAM role                                      | `bool`        | `false`                           |    no    |
+| use_ssm_parameter_store      | Set this to `true` to use SSM to store the Lacework agent access token              | `bool`        | `false`                           |    no    |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ locals {
     local.environment_json,
     {
       "essential" : true,
-      "image" : "lacework/datacollector",
+      "image" : "${var.lacework_datacollector_image}",
       "mountPoints" : [
         {
           "readOnly" : true,

--- a/variables.tf
+++ b/variables.tf
@@ -44,6 +44,12 @@ variable "lacework_access_token" {
   description = "The access token for the Lacework agent"
 }
 
+variable "lacework_datacollector_image" {
+  type        = string
+  description = "The image used to deploy the Lacework datacollector."
+  default     = "lacework/datacollector:latest"
+}
+
 variable "lacework_server_url" {
   type        = string
   default     = ""


### PR DESCRIPTION
With the current version of this module always the latest version of the Lacework datacollectod is pulled from the public registry hosted on Docker Hub.

This PR allows the user to specify the datacollector image while using `lacework/datacollector:latest` as default.
With this change a user can specify a specific version of the image used or even use a different (internal) container registry.