### PR TITLE
fix(CPLAT-672): Update references to api.lacework.net

### DIFF
--- a/examples/server-url/README.md
+++ b/examples/server-url/README.md
@@ -9,6 +9,6 @@ module "lacework_ecs_datacollector" {
 
   ecs_cluster_arn       = "arn:aws:ecs:us-east-1:123456789012:cluster/example-cluster"
   lacework_access_token = "0123456789ABCDEF0123456789ABCDEF"
-  lacework_server_url   = "https://api.lacework.net"
+  lacework_server_url   = "https://agent.lacework.net"
 }
 ```

--- a/examples/server-url/main.tf
+++ b/examples/server-url/main.tf
@@ -5,5 +5,5 @@ module "lacework_ecs_datacollector" {
 
   ecs_cluster_arn       = "arn:aws:ecs:us-east-1:123456789012:cluster/example-cluster"
   lacework_access_token = "0123456789ABCDEF0123456789ABCDEF"
-  lacework_server_url   = "https://api.lacework.net"
+  lacework_server_url   = "https://agent.lacework.net"
 }


### PR DESCRIPTION
## Summary
Refer [CPLAT-672](https://lacework.atlassian.net/browse/CPLAT-672)
We are moving to new dns naming conventions api.lacework.net => agent.lacework.net

## How did you test this change?
Manually - RAIN-59923, RAIN-59923

## Issue
[CPLAT-672](https://lacework.atlassian.net/browse/CPLAT-672)

[CPLAT-672]: https://lacework.atlassian.net/browse/CPLAT-672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CPLAT-672]: https://lacework.atlassian.net/browse/CPLAT-672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ