### PR TITLE
Add variable for passing in the LaceworkConfig env var

### DIFF
--- a/examples/customizing-config/README.md
+++ b/examples/customizing-config/README.md
@@ -1,0 +1,19 @@
+# Customizing the lacework config for the collector
+
+This example is a copy of the default one, with the additional option of passing
+additional config down to the collector.
+
+```hcl
+module "lacework_ecs_datacollector" {
+  source  = "lacework/ecs-agent/aws"
+  version = "~> 0.1"
+
+  ...
+
+  lacework_config = jsonencode({
+    codeaware = {
+      enable = "all"
+    }
+  })
+}
+```

--- a/examples/customizing-config/main.tf
+++ b/examples/customizing-config/main.tf
@@ -1,0 +1,22 @@
+provider "aws" {}
+
+provider "lacework" {}
+
+resource "lacework_agent_access_token" "ecs" {
+  name        = "prod"
+  description = "ecs deployment for production env"
+}
+
+module "lacework_ecs_datacollector" {
+  source = "../../"
+
+  ecs_cluster_arn       = "arn:aws:ecs:us-east-1:123456789012:cluster/example-cluster"
+  lacework_access_token = lacework_agent_access_token.ecs.token
+
+  # inject some additional configuration into the lacework config
+  lacework_config = jsonencode({
+    codeaware = {
+      enable = "all"
+    }
+  })
+}

--- a/examples/customizing-config/versions.tf
+++ b/examples/customizing-config/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = ">= 0.12.31"
+
+  required_providers {
+    aws = "~> 3.0"
+    lacework = {
+      source  = "lacework/lacework"
+      version = "~> 0.4"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -13,6 +13,9 @@ locals {
       length(var.lacework_server_url) > 0 ? ([{
         "name" : "LaceworkServerUrl", "value" : var.lacework_server_url
       }]) : ([]),
+      var.lacework_config != null ? ([{
+        "name" : "LaceworkConfig", "value" : var.lacework_config
+      }]) : ([]),
     ])
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -109,3 +109,9 @@ variable "use_ssm_parameter_store" {
   default     = false
   description = "Set this to `true` to use SSM to store the Lacework agent access token"
 }
+
+variable "lacework_config" {
+  type = string
+  default = null
+  description = "The Lacework agent configuration in JSON format"
+}


### PR DESCRIPTION
## Summary

The ENV var `LaceworkConfig` seems to be a somewhat hidden way of passing additional `config.json` config without having to somehow inject a file via a sidecar or something. This just adds a var to optionally add that to the task defintion.

## How did you test this change?

Deployed it in our environment and having Clayton Sopel confirm things.
